### PR TITLE
Daemon build placeholders added for obj/consensus & obj/wallet.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -230,10 +230,6 @@ CChainParams &Params(CBaseChainParams::Network network) {
             return mainParams;
         case CBaseChainParams::TESTNET:
             return testNetParams;
-        /*case CBaseChainParams::REGTEST:
-            return regTestParams;
-        case CBaseChainParams::UNITTEST:
-            return unitTestParams;*/
         default:
             assert(false && "Unimplemented network");
             return mainParams;

--- a/src/obj/consensus/placeholder.txt
+++ b/src/obj/consensus/placeholder.txt
@@ -1,0 +1,1 @@
+#placeholder file

--- a/src/obj/wallet/placeholder.txt
+++ b/src/obj/wallet/placeholder.txt
@@ -1,0 +1,1 @@
+#placeholder file


### PR DESCRIPTION
This commit might help your Travis Ci daemon build by adding the obj/consensus and obj/wallet.  Those directories are needed for the daemon build and without them, it can't compile.  

Also, try using these commands to build the daemon and qt wallet on Travis Ci:

Daemon:
cd DarkSilk-Release-Candidate/src/secp256k1 && ./autogen.sh && ./configure --enable-module-recovery && make && cd .. && sudo make -f makefile.unix USE_UPNP=0

Qt Wallet:
cd DarkSilk-Release-Candidate && qmake -qt=qt5 "USE_QRCODE=1" "USE_NATIVE_I2P=1" && make
